### PR TITLE
[ZBR-86] 회원가입 수정

### DIFF
--- a/src/main/java/com/zeebra/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/zeebra/domain/auth/controller/AuthController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.zeebra.domain.auth.dto.LoginRequest;
 import com.zeebra.domain.auth.dto.LoginResponse;
 import com.zeebra.domain.auth.dto.LoginSuccess;
+import com.zeebra.domain.auth.dto.SignupRequest;
+import com.zeebra.domain.auth.dto.SignupResponse;
 import com.zeebra.domain.auth.service.AuthService;
 import com.zeebra.global.ApiResponse;
 import com.zeebra.global.web.CookieUtil;
@@ -26,7 +28,6 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 	private static final String ACCESS_TOKEN_COOKIE_NAME = "__Host-AT";
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "__Host-RT";
-
 
 	private final AuthService authService;
 
@@ -59,5 +60,12 @@ public class AuthController {
 		CookieUtil.clearAuthCookies(response);
 
 		return ApiResponse.success("Logged out");
+	}
+
+	@Operation(summary = "회원가입", description = "회원가입을 합니다. 비밀번호 길이는 8~20자, 영문자, 숫자, 특수문자 .*[!@#$%^&*()_+=- 가 포함되어야 합니다.")
+	@PostMapping("/signup")
+	public ApiResponse<SignupResponse> signup(@RequestBody @Valid SignupRequest request) {
+
+		return ApiResponse.success(authService.register(request));
 	}
 }

--- a/src/main/java/com/zeebra/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/zeebra/domain/auth/dto/LoginResponse.java
@@ -1,7 +1,5 @@
 package com.zeebra.domain.auth.dto;
 
-import com.zeebra.domain.member.dto.MemberInfo;
-
 public record LoginResponse(MemberInfo user) {
 	public static LoginResponse of(MemberInfo user) {
 		return new LoginResponse(user);

--- a/src/main/java/com/zeebra/domain/auth/dto/LoginSuccess.java
+++ b/src/main/java/com/zeebra/domain/auth/dto/LoginSuccess.java
@@ -1,7 +1,5 @@
 package com.zeebra.domain.auth.dto;
 
-import com.zeebra.domain.member.dto.MemberInfo;
-
 public record LoginSuccess(
 	String accessToken,
    	String refreshToken,

--- a/src/main/java/com/zeebra/domain/auth/dto/MemberInfo.java
+++ b/src/main/java/com/zeebra/domain/auth/dto/MemberInfo.java
@@ -1,4 +1,4 @@
-package com.zeebra.domain.member.dto;
+package com.zeebra.domain.auth.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/com/zeebra/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/zeebra/domain/auth/dto/SignupRequest.java
@@ -1,4 +1,4 @@
-package com.zeebra.domain.member.dto;
+package com.zeebra.domain.auth.dto;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/zeebra/domain/auth/dto/SignupResponse.java
+++ b/src/main/java/com/zeebra/domain/auth/dto/SignupResponse.java
@@ -1,4 +1,4 @@
-package com.zeebra.domain.member.dto;
+package com.zeebra.domain.auth.dto;
 
 import com.zeebra.domain.member.entity.Member;
 

--- a/src/main/java/com/zeebra/domain/auth/service/AuthService.java
+++ b/src/main/java/com/zeebra/domain/auth/service/AuthService.java
@@ -2,8 +2,12 @@ package com.zeebra.domain.auth.service;
 
 import com.zeebra.domain.auth.dto.LoginRequest;
 import com.zeebra.domain.auth.dto.LoginSuccess;
+import com.zeebra.domain.auth.dto.SignupRequest;
+import com.zeebra.domain.auth.dto.SignupResponse;
 
 public interface AuthService {
+	SignupResponse register(SignupRequest request);
+
 	LoginSuccess login(LoginRequest request);
 
 	void logout(String accessToken, String refreshToken);

--- a/src/main/java/com/zeebra/domain/member/controller/MemberController.java
+++ b/src/main/java/com/zeebra/domain/member/controller/MemberController.java
@@ -1,33 +1,21 @@
 package com.zeebra.domain.member.controller;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.zeebra.domain.member.dto.SignupRequest;
-import com.zeebra.domain.member.dto.SignupResponse;
 import com.zeebra.domain.member.service.MemberService;
-import com.zeebra.global.ApiResponse;
 
-import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/members")
+@RequiredArgsConstructor
 public class MemberController {
 
-	private MemberService memberService;
+	private final MemberService memberService;
 
-	public MemberController(MemberService memberService) {
-		this.memberService = memberService;
-	}
-
-	@PostMapping("/signup")
-	public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody @Valid SignupRequest request) {
-
-
-
-		return ResponseEntity.created(null).body(ApiResponse.success(memberService.register(request)));
-	}
+	// 향후 회원 정보 조회, 수정 등의 엔드포인트가 여기에 추가됩니다
+	// @GetMapping("/me")
+	// @PatchMapping("/nickname")
+	// @DeleteMapping
 }

--- a/src/main/java/com/zeebra/domain/member/service/MemberService.java
+++ b/src/main/java/com/zeebra/domain/member/service/MemberService.java
@@ -1,13 +1,9 @@
 package com.zeebra.domain.member.service;
 
-import com.zeebra.domain.member.dto.SignupRequest;
-import com.zeebra.domain.member.dto.SignupResponse;
-
 public interface MemberService {
-	SignupResponse register(SignupRequest request);
-	// public void login(String email, String password);
-	// public void logout();
-	// public void updateNickname(String nickname);
-	// public void updatePassword(String password);
-	// public void deleteAccount();
+	// 향후 추가될 메소드들
+	// MemberDetailResponse getMemberInfo(Long memberId);
+	// void updateNickname(Long memberId, String nickname);
+	// void updatePassword(Long memberId, String oldPassword, String newPassword);
+	// void deleteAccount(Long memberId);
 }

--- a/src/main/java/com/zeebra/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/zeebra/domain/member/service/MemberServiceImpl.java
@@ -1,17 +1,9 @@
 package com.zeebra.domain.member.service;
 
-import com.zeebra.domain.notification.event.MemberSignUpEvent;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.zeebra.domain.member.dto.SignupRequest;
-import com.zeebra.domain.member.dto.SignupResponse;
-import com.zeebra.domain.member.entity.Member;
 import com.zeebra.domain.member.repository.MemberRepository;
-import com.zeebra.global.ErrorCode.MemberErrorCode;
-import com.zeebra.global.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,41 +13,9 @@ public class MemberServiceImpl implements MemberService{
 
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
-    private final ApplicationEventPublisher eventPublisher;
-
-	@Transactional
-	public SignupResponse register(SignupRequest request) {
-
-		String email = request.memberEmail().trim().toLowerCase();
-
-		if(memberRepository.existsByUserLoginIdAndDeletedAtIsNull(request.userLoginId())){
-			throw new BusinessException(MemberErrorCode.DUPLICATE_LOGIN_ID);
-		}
-
-		if(memberRepository.existsByMemberEmailAndDeletedAtIsNull(email)){
-			throw new BusinessException(MemberErrorCode.DUPLICATE_EMAIL);
-		}
-
-		if(memberRepository.existsByNicknameAndDeletedAtIsNull(request.nickname())){
-			throw new BusinessException(MemberErrorCode.DUPLICATE_NICKNAME);
-		}
-
-		String rawPassword = request.password();
-
-		String encodedPassword = passwordEncoder.encode(rawPassword);
-
-		Member member = Member.createMember(request.userLoginId(), request.memberName(), request.memberEmail(),
-			request.nickname(), request.memberBirth(), request.memberGender(), encodedPassword);
-
-		Member saved = memberRepository.save(member);
-        eventPublisher.publishEvent(new MemberSignUpEvent(member.getId(), member.getNickname()));
-
-		return SignupResponse.of(saved);
-	}
 
 
-	// public void login(String email, String password) {}
-	// public void logout() {}
+
 	// public void updateNickname(String nickname) {}
 	// public void updatePassword(String password) {}
 	// public void deleteAccount() {}

--- a/src/main/java/com/zeebra/domain/notification/dto/NotificationRequest.java
+++ b/src/main/java/com/zeebra/domain/notification/dto/NotificationRequest.java
@@ -1,13 +1,14 @@
 package com.zeebra.domain.notification.dto;
 
-import com.zeebra.domain.member.dto.MemberInfo;
+import java.time.LocalDateTime;
+
+import com.zeebra.domain.auth.dto.MemberInfo;
 import com.zeebra.domain.notification.entity.NotificationType;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Setter

--- a/src/main/java/com/zeebra/global/config/SecurityConfig.java
+++ b/src/main/java/com/zeebra/global/config/SecurityConfig.java
@@ -3,10 +3,12 @@ package com.zeebra.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -38,18 +40,26 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-		// 임시로 모든 api 열어둠
 		http
+			.headers(headers -> headers
+				.contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'; script-src 'self' "))
+				.frameOptions(frameOptions -> frameOptions.deny()))
+			.cors(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(SWAGGER_WHITELIST).permitAll()
-				.requestMatchers("/api/auth/**", "/api/products", "/api/products/**").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/products", "/api/products/**").permitAll()
+				.requestMatchers("/api/auth/**").permitAll()
 				.anyRequest().authenticated())
-			.csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
+			.csrf(csrf -> csrf
+				.ignoringRequestMatchers("/api/auth/**", "/api/products", "/api/products/**")
+				.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.exceptionHandling(ex -> ex
 				.authenticationEntryPoint(authProblemHandler)
 				.accessDeniedHandler(authProblemHandler))
+            .sessionManagement(session -> 
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 		return http.build();
 	}

--- a/src/main/java/com/zeebra/global/web/CookieUtil.java
+++ b/src/main/java/com/zeebra/global/web/CookieUtil.java
@@ -16,10 +16,11 @@ public final class CookieUtil {
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "__Host-RT";
 
 	private static final boolean HTTP_ONLY = true;
-	private static final String SAME_SITE = "Lax";
 	private static final String PATH = "/";
-
-	private static boolean secure = true;
+	@Value("${auth.cookie.sameSite}")
+	private static String SAME_SITE;
+	@Value("${auth.cookie.secure}")
+	private static boolean secure;
 
 	private CookieUtil() {}
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,7 @@ spring:
 
 server:
   port: 8080
+  forward-headers-strategy: framework
 
 jwt:
   secret-key: ${JWT_SECRET}
@@ -34,3 +35,8 @@ spring.jpa:
   properties:
     hibernate.format_sql: true
   show-sql: false
+
+auth:
+  cookie:
+    secure: true
+    same-site: Lax


### PR DESCRIPTION
## 관련 이슈
- Jira: ZBR-86
- GitHub: Refs #42

## 어떤 이유로 MR을 하셨나요?
- [x] 코드 개선

## 스크린샷 및 간단한 설명
회원가입 관련 로직을 `Member` 도메인에서 `Auth` 도메인으로 이동시키고 코드 구조를 리팩토링했습니다.  
주요 변경 사항:
- 회원가입 API를 `AuthController`로 이전.
- 관련 DTO 및 요청/응답 구조를 `auth.dto` 패키지로 재조정.
- 보안 설정(`JwtFilter`, `SecurityConfig`)에서 회원가입 경로 업데이트.
- 회원가입 처리 시 이벤트 퍼블리셔 추가 적용.
- `AuthService`에 회원가입 로직 통합.

## MR 전에 확인해주세요
- [x] **develop** 브랜치로 PR을 생성했나요?
- [x] Docker 빌드 후 테스트를 완료했나요?
- [x] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [x] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?