### PR TITLE
[ZBR-141] 주문 목록 조회 API 및 서비스 추가

### DIFF
--- a/src/main/java/com/zeebra/domain/order/controller/OrderController.java
+++ b/src/main/java/com/zeebra/domain/order/controller/OrderController.java
@@ -1,18 +1,27 @@
 package com.zeebra.domain.order.controller;
 
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.zeebra.domain.order.dto.CreateOrderRequest;
 import com.zeebra.domain.order.dto.CreateOrderResponse;
+import com.zeebra.domain.order.dto.ReadOrderListResponse;
+import com.zeebra.domain.order.entity.OrderStatus;
 import com.zeebra.domain.order.service.OrderService;
 import com.zeebra.global.ApiResponse;
 import com.zeebra.global.security.jwt.JwtProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +41,24 @@ public class OrderController {
 		Long memberId = principal.getMemberId();
 
 		return ApiResponse.success(orderService.createOrder(memberId, request));
+	}
+
+	@Operation(summary = "주문 목록 조회 API", description = "주문한 내역을 조건별로 조회합니다.")
+	@GetMapping()
+	public ApiResponse<ReadOrderListResponse> getOrders(
+		@AuthenticationPrincipal JwtProvider.JwtUserPrincipal principal,
+		@Parameter(description = "조회 시작일 (yyyy-MM-dd)", required = false)
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+		@Parameter(description = "조회 종료일 (yyyy-MM-dd)", required = false)
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+		@Parameter(description = "주문 상태", required = false)
+		@RequestParam(required = false) OrderStatus orderStatus,
+		Pageable pageable
+	) {
+		Long memberId = principal.getMemberId();
+
+		ReadOrderListResponse response = orderService.getOrderList(memberId, startDate, endDate, orderStatus, pageable);
+
+		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/com/zeebra/domain/order/dto/ReadOrderListResponse.java
+++ b/src/main/java/com/zeebra/domain/order/dto/ReadOrderListResponse.java
@@ -1,0 +1,23 @@
+package com.zeebra.domain.order.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+public record ReadOrderListResponse(
+	List<OrderResponse> orders,
+	int currentPage,
+	int totalPages,
+	long totalElements,
+	boolean hasNext
+) {
+	public static ReadOrderListResponse of(Page<OrderResponse> orderPage) {
+		return new ReadOrderListResponse(
+			orderPage.getContent(),
+			orderPage.getNumber(),
+			orderPage.getTotalPages(),
+			orderPage.getTotalElements(),
+			orderPage.hasNext()
+		);
+	}
+}

--- a/src/main/java/com/zeebra/domain/order/repository/OrderQueryRepository.java
+++ b/src/main/java/com/zeebra/domain/order/repository/OrderQueryRepository.java
@@ -1,0 +1,96 @@
+package com.zeebra.domain.order.repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zeebra.domain.order.entity.Order;
+import com.zeebra.domain.order.entity.OrderStatus;
+import com.zeebra.domain.order.entity.QOrder;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryRepository {
+	private final JPAQueryFactory queryFactory;
+	private final QOrder order = QOrder.order;
+
+
+
+	public Page<Order> findOrdersByConditions(Long memberId, LocalDate startDate, LocalDate endDate, OrderStatus orderStatus, Pageable pageable){
+		List<Order> orders = queryFactory
+			.selectFrom(order)
+			.where(
+				memberIdEq(memberId),
+				orderTimeBetween(startDate, endDate),
+				orderStatusEq(orderStatus)
+			)
+			.orderBy(getOrderSpecifier(pageable))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+		Long total = queryFactory
+			.select(order.count())
+			.from(order)
+			.where(
+				memberIdEq(memberId),
+				orderTimeBetween(startDate, endDate),
+				orderStatusEq(orderStatus)
+			)
+			.fetchOne();
+
+		return new PageImpl<>(orders, pageable, total != null ? total : 0L);
+	}
+
+	private BooleanExpression memberIdEq(Long memberId) {
+		return memberId != null ? order.memberId.eq(memberId) : null;
+	}
+
+	private BooleanExpression orderTimeBetween(LocalDate startDate, LocalDate endDate) {
+		if (startDate != null && endDate != null) {
+			LocalDateTime startDateTime = startDate.atStartOfDay();
+			LocalDateTime endDateTime = endDate.atStartOfDay();
+			return order.orderTime.between(startDateTime, endDateTime);
+		}
+		if (startDate != null) {
+			return order.orderTime.goe(startDate.atStartOfDay());
+		}
+		if (endDate != null) {
+			return order.orderTime.lt(endDate.atStartOfDay());
+		}
+		return null;
+	}
+
+	private BooleanExpression orderStatusEq(OrderStatus orderStatus) {
+		return orderStatus != null ? order.orderStatus.eq(orderStatus) : null;
+	}
+
+	private OrderSpecifier<?>[] getOrderSpecifier(Pageable pageable) {
+		if (pageable.getSort().isEmpty()) {
+			return new OrderSpecifier[]{order.orderTime.desc()};
+		}
+
+		return pageable.getSort().stream()
+			.map(sortOrder -> {
+				String property = sortOrder.getProperty();
+				boolean isAsc = sortOrder.isAscending();
+
+				return switch (property) {
+					case "orderTime" -> isAsc ? order.orderTime.asc() : order.orderTime.desc();
+					case "totalAmount" -> isAsc ? order.totalAmount.asc() : order.totalAmount.desc();
+					case "orderNumber" -> isAsc ? order.orderNumber.asc() : order.orderNumber.desc();
+					default -> order.orderTime.desc();
+				};
+			})
+			.toArray(OrderSpecifier[]::new);
+	}
+}

--- a/src/main/java/com/zeebra/domain/order/service/OrderService.java
+++ b/src/main/java/com/zeebra/domain/order/service/OrderService.java
@@ -1,8 +1,13 @@
 package com.zeebra.domain.order.service;
 
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Pageable;
+
 import com.zeebra.domain.order.dto.CreateOrderRequest;
 import com.zeebra.domain.order.dto.CreateOrderResponse;
 import com.zeebra.domain.order.dto.OrderInfo;
+import com.zeebra.domain.order.dto.ReadOrderListResponse;
 import com.zeebra.domain.order.entity.OrderItemStatus;
 import com.zeebra.domain.order.entity.OrderStatus;
 
@@ -14,4 +19,6 @@ public interface OrderService {
 	void updateOrderStatus(Long orderId, OrderStatus orderStatus, String idempotencyKey);
 
 	void updateAllOrderItemsStatus(Long orderId, OrderItemStatus orderItemStatus);
+
+	ReadOrderListResponse getOrderList(Long memberId, LocalDate startDate, LocalDate endDate, OrderStatus orderStatus, Pageable pageable);
 }

--- a/src/main/java/com/zeebra/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/zeebra/domain/order/service/OrderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.zeebra.domain.payment.service;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -9,6 +10,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +23,7 @@ import com.zeebra.domain.order.dto.OrderInfo;
 import com.zeebra.domain.order.dto.OrderItemResponse;
 import com.zeebra.domain.order.dto.OrderResponse;
 import com.zeebra.domain.order.dto.ProductInfo;
+import com.zeebra.domain.order.dto.ReadOrderListResponse;
 import com.zeebra.domain.order.dto.SalesItem;
 import com.zeebra.domain.order.entity.Order;
 import com.zeebra.domain.order.entity.OrderHistory;
@@ -29,6 +33,7 @@ import com.zeebra.domain.order.entity.OrderStatus;
 import com.zeebra.domain.order.repository.OrderHistoryRepository;
 import com.zeebra.domain.order.repository.OrderItemQueryRepository;
 import com.zeebra.domain.order.repository.OrderItemRepository;
+import com.zeebra.domain.order.repository.OrderQueryRepository;
 import com.zeebra.domain.order.repository.OrderRepository;
 import com.zeebra.domain.order.service.OrderService;
 import com.zeebra.domain.product.entity.Sales;
@@ -53,6 +58,7 @@ public class OrderServiceImpl implements OrderService {
 	private static final int MAX_IDEMPOTENCY_KEY_LENGTH = 255;
 
 	private final OrderRepository orderRepository;
+	private final OrderQueryRepository orderQueryRepository;
 	private final OrderItemRepository orderItemRepository;
 	private final OrderItemQueryRepository orderItemQueryRepository;
 	private final OrderHistoryRepository orderHistoryRepository;
@@ -112,6 +118,35 @@ public class OrderServiceImpl implements OrderService {
 	public void updateAllOrderItemsStatus(Long orderId, OrderItemStatus orderItemStatus) {
 		List<OrderItem> orderItems = orderItemRepository.findByOrderId(orderId);
 		orderItems.forEach(orderItem -> orderItem.updateOrderItemStatus(orderItemStatus));
+	}
+
+	public ReadOrderListResponse getOrderList(Long memberId, LocalDate startDate, LocalDate endDate, OrderStatus orderStatus, Pageable pageable) {
+		if (memberId == null) {
+			log.error("[주문 목록 조회 실패] memberId가 null입니다.");
+			throw new BusinessException(OrderErrorCode.INVALID_ORDER_REQUEST);
+		}
+
+		if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+			log.error("[주문 목록 조회 실패] 시작일이 종료일보다 늦습니다. startDate: {}, endDate: {}", startDate, endDate);
+			throw new BusinessException(OrderErrorCode.INVALID_ORDER_REQUEST);
+		}
+
+		LocalDate adjustedEndDate = endDate != null ? endDate.plusDays(1) : null;
+
+		Page<Order> orderPage = orderQueryRepository.findOrdersByConditions(
+			memberId,
+			startDate,
+			adjustedEndDate,
+			orderStatus,
+			pageable
+		);
+
+		Page<OrderResponse> orderResponsePage = orderPage.map(order -> {
+			List<OrderItemResponse> orderItems = orderItemQueryRepository.findOrderItemsByOrderId(order.getId());
+			return OrderResponse.of(order, orderItems);
+		});
+
+		return ReadOrderListResponse.of(orderResponsePage);
 	}
 
 	private Optional<CreateOrderResponse> findExistingOrder(String clientRequestId, Long memberId) {


### PR DESCRIPTION
## 관련 이슈
- Jira: ZBR-141
- GitHub: Closes #116

## 어떤 이유로 MR을 하셨나요?
- [x] 기능 추가

## 스크린샷 및 간단한 설명
> 주문 목록 조회 API 및 서비스가 추가되었습니다.
- 주문 목록 조회 기능 구현 (`getOrderList` 메서드)
- `OrderQueryRepository`를 통한 조건 기반 주문 조회 기능 추가 (기간, 상태, 페이징)
- 조회 응답 DTO(`ReadOrderListResponse`) 도입
- `OrderController`에 관련 API 경로 추가

## MR 전에 확인해주세요
- [x] **develop** 브랜치로 PR을 생성했나요?
- [x] Docker 빌드 후 테스트를 완료했나요?
- [x] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [x] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?

[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ