### PR TITLE
[ZBR-144] 판매 상세 조회 API 및 서비스 추가

### DIFF
--- a/src/main/java/com/zeebra/domain/order/repository/OrderItemQueryRepository.java
+++ b/src/main/java/com/zeebra/domain/order/repository/OrderItemQueryRepository.java
@@ -77,7 +77,6 @@ public class OrderItemQueryRepository {
 	}
 	public ProductInfo findProductInfoBySaleId(Long saleId) {
 		if (saleId == null) {
-			log.error("[상품 정보 조회 실패] saleId가 null입니다.");
 			return null;
 		}
 
@@ -100,13 +99,10 @@ public class OrderItemQueryRepository {
 				.where(sales.id.eq(saleId))
 				.fetch();
 		} catch (Exception e) {
-			log.error("[상품 정보 조회 실패] 데이터베이스 조회 중 오류가 발생했습니다. saleId: {}, error: {}",
-				saleId, e.getMessage(), e);
 			return null;
 		}
 
 		if (results.isEmpty()) {
-			log.warn("[상품 정보 조회 실패] 해당 saleId로 상품을 찾을 수 없습니다. saleId: {}", saleId);
 			return null;
 		}
 

--- a/src/main/java/com/zeebra/domain/product/controller/SalesController.java
+++ b/src/main/java/com/zeebra/domain/product/controller/SalesController.java
@@ -1,18 +1,29 @@
 package com.zeebra.domain.product.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zeebra.domain.product.dto.SalesDetailResponse;
 import com.zeebra.domain.product.dto.SalesRequest;
 import com.zeebra.domain.product.dto.SalesResponse;
 import com.zeebra.domain.product.service.SalesService;
 import com.zeebra.global.ApiResponse;
 import com.zeebra.global.security.jwt.JwtProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Sales API", description = "판매 관련 API")
 public class SalesController {
 
     private final SalesService salesService;
@@ -28,4 +39,11 @@ public class SalesController {
         Long memberId = principal.getMemberId();
         return salesService.deleteSales(memberId, salesId);
     }
+
+	@Operation(summary = "판매 내역 상세 조회 API", description = "salesId를 통해서 판매 상세를 조회합니다.")
+	@GetMapping("api/sales/{salesId}")
+	public ApiResponse<SalesDetailResponse> getSalesDetail(@PathVariable Long salesId, @AuthenticationPrincipal JwtProvider.JwtUserPrincipal principal) {
+		Long memberId = principal.getMemberId();
+		return ApiResponse.success(salesService.getSalesDetail(memberId, salesId));
+	}
 }

--- a/src/main/java/com/zeebra/domain/product/dto/SalesDetailResponse.java
+++ b/src/main/java/com/zeebra/domain/product/dto/SalesDetailResponse.java
@@ -1,0 +1,23 @@
+package com.zeebra.domain.product.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.zeebra.domain.product.entity.SalesStatus;
+
+public record SalesDetailResponse(
+	Long salesId,
+	Long productOptionId,
+	BigDecimal price,
+	BigDecimal soldPrice,
+	SalesStatus salesStatus,
+	int stock,
+	LocalDateTime createdAt,
+	LocalDateTime soldAt,
+	String thumbnail,
+	String productName,
+	List<SalesItemOptions> options
+) {
+
+}

--- a/src/main/java/com/zeebra/domain/product/dto/SalesItemOptions.java
+++ b/src/main/java/com/zeebra/domain/product/dto/SalesItemOptions.java
@@ -1,0 +1,7 @@
+package com.zeebra.domain.product.dto;
+
+public record SalesItemOptions(String name, String value) {
+	public static SalesItemOptions of(String name, String value){
+		return new SalesItemOptions(name, value);
+	}
+}

--- a/src/main/java/com/zeebra/domain/product/repository/SalesQueryRepository.java
+++ b/src/main/java/com/zeebra/domain/product/repository/SalesQueryRepository.java
@@ -1,10 +1,17 @@
 package com.zeebra.domain.product.repository;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zeebra.domain.product.dto.SalesDetailResponse;
+import com.zeebra.domain.product.dto.SalesItemOptions;
+import com.zeebra.domain.product.entity.QOptionName;
+import com.zeebra.domain.product.entity.QProduct;
 import com.zeebra.domain.product.entity.QProductOption;
 import com.zeebra.domain.product.entity.QSales;
 import com.zeebra.domain.product.entity.Sales;
@@ -20,6 +27,9 @@ public class SalesQueryRepository {
 
     private final QProductOption productOption = QProductOption.productOption;
     private final QSales sales = QSales.sales;
+	private final QProduct product = QProduct.product;
+	private final QProductOption optionCombination = QProductOption.productOption;
+	private final QOptionName optionName = QOptionName.optionName;
     private final JPAQueryFactory queryFactory;
 
     public BigDecimal cheapestSalesPrice(Long productOptionId) {
@@ -52,5 +62,64 @@ public class SalesQueryRepository {
 		}
 		
 		return result;
+	}
+
+	public SalesDetailResponse findSalesDetailById(Long salesId, Long memberId) {
+		Tuple baseInfo = queryFactory
+			.select(
+				sales.id,
+				sales.productOptionId,
+				sales.price,
+				sales.soldPrice,
+				sales.salesStatus,
+				sales.stock,
+				sales.createdTime,
+				sales.soldAt,
+				product.thumbnail,
+				product.name
+			)
+			.from(sales)
+			.join(productOption).on(sales.productOptionId.eq(productOption.id))
+			.join(product).on(productOption.productId.eq(product.id))
+			.where(
+				sales.id.eq(salesId),
+				sales.memberId.eq(memberId)
+			)
+			.fetchOne();
+
+		if (baseInfo == null) {
+			return null;
+		}
+
+		List<SalesItemOptions> options = queryFactory
+			.select(optionName.name, optionName.value)
+			.from(sales)
+			.join(productOption).on(sales.productOptionId.eq(productOption.id))
+			.join(optionName).on(productOption.id.eq(optionName.id))
+			.where(sales.id.eq(salesId))
+			.fetch()
+			.stream()
+			.filter(tuple -> tuple.get(optionName.name) != null)
+			.map(tuple -> SalesItemOptions.of(
+				tuple.get(optionName.name),
+				tuple.get(optionName.value)
+			))
+			.distinct()
+			.collect(Collectors.toList());
+
+
+		return new SalesDetailResponse(
+			baseInfo.get(sales.id),
+			baseInfo.get(sales.productOptionId),
+			baseInfo.get(sales.price),
+			baseInfo.get(sales.soldPrice),
+			baseInfo.get(sales.salesStatus),
+			baseInfo.get(sales.stock),
+			baseInfo.get(sales.createdTime),
+			baseInfo.get(sales.soldAt),
+			baseInfo.get(product.thumbnail),
+			baseInfo.get(product.name),
+			options
+		);
 	}
 }

--- a/src/main/java/com/zeebra/domain/product/repository/SalesRepository.java
+++ b/src/main/java/com/zeebra/domain/product/repository/SalesRepository.java
@@ -1,7 +1,11 @@
 package com.zeebra.domain.product.repository;
 
-import com.zeebra.domain.product.entity.Sales;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.zeebra.domain.product.entity.Sales;
+
 public interface SalesRepository extends JpaRepository<Sales, Long> {
+	Optional<Sales> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/zeebra/domain/product/service/SalesService.java
+++ b/src/main/java/com/zeebra/domain/product/service/SalesService.java
@@ -1,6 +1,7 @@
 package com.zeebra.domain.product.service;
 
 import com.zeebra.domain.order.dto.SalesItem;
+import com.zeebra.domain.product.dto.SalesDetailResponse;
 import com.zeebra.domain.product.dto.SalesRequest;
 import com.zeebra.domain.product.dto.SalesResponse;
 import com.zeebra.global.ApiResponse;
@@ -12,4 +13,6 @@ public interface SalesService {
     public ApiResponse<Void> deleteSales(Long memberId, Long salesId);
 
 	SalesItem findCheapestSalesByProductOptionId(Long productOptionId);
+
+	SalesDetailResponse getSalesDetail(Long memberId, Long salesId);
 }

--- a/src/main/java/com/zeebra/domain/product/service/SalesServiceImp.java
+++ b/src/main/java/com/zeebra/domain/product/service/SalesServiceImp.java
@@ -8,15 +8,18 @@ import org.springframework.transaction.annotation.Transactional;
 import com.zeebra.domain.member.entity.Member;
 import com.zeebra.domain.member.repository.MemberRepository;
 import com.zeebra.domain.order.dto.SalesItem;
+import com.zeebra.domain.product.dto.SalesDetailResponse;
 import com.zeebra.domain.product.dto.SalesRequest;
 import com.zeebra.domain.product.dto.SalesResponse;
 import com.zeebra.domain.product.entity.ProductOption;
 import com.zeebra.domain.product.entity.Sales;
 import com.zeebra.domain.product.entity.SalesStatus;
+import com.zeebra.domain.product.repository.ProductOptionQueryRepository;
 import com.zeebra.domain.product.repository.ProductOptionRepository;
 import com.zeebra.domain.product.repository.SalesQueryRepository;
 import com.zeebra.domain.product.repository.SalesRepository;
 import com.zeebra.global.ApiResponse;
+import com.zeebra.global.ErrorCode.CommonErrorCode;
 import com.zeebra.global.ErrorCode.OrderErrorCode;
 import com.zeebra.global.exception.BusinessException;
 
@@ -32,8 +35,9 @@ public class SalesServiceImp implements SalesService {
     private final MemberRepository memberRepository;
     private final ProductOptionRepository productOptionRepository;
 	private final SalesQueryRepository salesQueryRepository;
+	private final ProductOptionQueryRepository productOptionQueryRepository;
 
-    private Sales toSales(ProductOption productOption, Member member, SalesRequest request) {
+	private Sales toSales(ProductOption productOption, Member member, SalesRequest request) {
         return new Sales(
                 productOption.getId(),
                 member.getId(),
@@ -101,5 +105,15 @@ public class SalesServiceImp implements SalesService {
 		}
 
 		return SalesItem.of(sales.getId(), sales.getStock(), sales.getPrice());
+	}
+
+	public SalesDetailResponse getSalesDetail(Long memberId, Long salesId) {
+		SalesDetailResponse salesDetailResponse = salesQueryRepository.findSalesDetailById(salesId, memberId);
+		if (salesDetailResponse == null) {
+			log.info("서비스임");
+			throw new BusinessException(CommonErrorCode.NOT_FOUND);
+		}
+
+		return salesDetailResponse;
 	}
 }


### PR DESCRIPTION
## 관련 이슈
- Jira: ZBR-144
- Github: Closes #120

## 어떤 이유로 MR을 하셨나요?
- [x] 기능 추가

## 스크린샷 및 간단한 설명
> 판매 상세 조회 API 및 서비스 기능을 추가했습니다.  
> - `SalesController`에 판매 상세 조회 API 경로 추가  
> - 판매 상세 및 옵션 데이터 조회 로직을 `SalesQueryRepository`를 통해 구현  
> - DTO 추가 (`SalesDetailResponse`, `SalesItemOptions`) 및 관련 예외 처리 포함  

## MR 전에 확인해주세요
- [x] **develop** 브랜치로 PR을 생성했나요?
- [x] Docker 빌드 후 테스트를 완료했나요?
- [x] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [x] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?  

[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ