### PR TITLE
[ZBR-143] 판매 목록 조회 API 및 서비스 추가

### DIFF
--- a/src/main/java/com/zeebra/domain/product/controller/SalesController.java
+++ b/src/main/java/com/zeebra/domain/product/controller/SalesController.java
@@ -1,21 +1,29 @@
 package com.zeebra.domain.product.controller;
 
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.zeebra.domain.product.dto.SalesDetailResponse;
+import com.zeebra.domain.product.dto.SalesListResponse;
 import com.zeebra.domain.product.dto.SalesRequest;
 import com.zeebra.domain.product.dto.SalesResponse;
+import com.zeebra.domain.product.entity.SalesStatus;
 import com.zeebra.domain.product.service.SalesService;
 import com.zeebra.global.ApiResponse;
 import com.zeebra.global.security.jwt.JwtProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,9 +49,25 @@ public class SalesController {
     }
 
 	@Operation(summary = "판매 내역 상세 조회 API", description = "salesId를 통해서 판매 상세를 조회합니다.")
-	@GetMapping("api/sales/{salesId}")
+	@GetMapping("/api/sales/{salesId}")
 	public ApiResponse<SalesDetailResponse> getSalesDetail(@PathVariable Long salesId, @AuthenticationPrincipal JwtProvider.JwtUserPrincipal principal) {
 		Long memberId = principal.getMemberId();
 		return ApiResponse.success(salesService.getSalesDetail(memberId, salesId));
+	}
+
+	@Operation(summary = "판매 내역 목록 조회 API", description = "현재 사용자의 모든 판매 목록을 조회합니다.")
+	@GetMapping("/api/sales")
+	public ApiResponse<SalesListResponse> getSalesList(@AuthenticationPrincipal JwtProvider.JwtUserPrincipal principal,
+		@Parameter(description = "조회 시작일 (yyyy-MM-dd)", required = false)
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+		@Parameter(description = "조회 종료일 (yyyy-MM-dd)", required = false)
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+		@Parameter(description = "판매 상태", required = false)
+		@RequestParam(required = false) SalesStatus salesStatus,
+		Pageable pageable) {
+		Long memberId = principal.getMemberId();
+
+		SalesListResponse response = salesService.getSalesList(memberId, startDate, endDate, salesStatus, pageable);
+		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/com/zeebra/domain/product/dto/SalesListResponse.java
+++ b/src/main/java/com/zeebra/domain/product/dto/SalesListResponse.java
@@ -1,0 +1,17 @@
+package com.zeebra.domain.product.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+public record SalesListResponse(
+	List<SalesDetailResponse> salesList,
+	int currentPage,
+	int totalPages,
+	long totalElements,
+	boolean hasNext
+) {
+	public static SalesListResponse of(Page<SalesDetailResponse> salesPage) {
+		return new SalesListResponse(salesPage.getContent(), salesPage.getNumber(), salesPage.getTotalPages(), salesPage.getTotalElements(), salesPage.hasNext());
+	}
+}

--- a/src/main/java/com/zeebra/domain/product/repository/SalesQueryRepository.java
+++ b/src/main/java/com/zeebra/domain/product/repository/SalesQueryRepository.java
@@ -1,12 +1,18 @@
 package com.zeebra.domain.product.repository;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zeebra.domain.product.dto.SalesDetailResponse;
 import com.zeebra.domain.product.dto.SalesItemOptions;
@@ -122,4 +128,64 @@ public class SalesQueryRepository {
 			options
 		);
 	}
+
+	public Page<SalesDetailResponse> findSalesDetailsByConditions(Long memberId, LocalDate startDate, LocalDate endDate, SalesStatus salesStatus, Pageable pageable) {
+		List<Long> salesIds = queryFactory
+			.select(sales.id)
+			.from(sales)
+			.where(
+				memberIdEq(memberId),
+				createdTimeBetween(startDate, endDate),
+				salesStatusEq(salesStatus)
+			)
+			.orderBy(sales.createdTime.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		if (salesIds.isEmpty()) {
+			return new PageImpl<>(List.of(), pageable, 0L);
+		}
+
+		Long total = queryFactory
+			.select(sales.count())
+			.from(sales)
+			.where(
+				memberIdEq(memberId),
+				createdTimeBetween(startDate, endDate),
+				salesStatusEq(salesStatus)
+			)
+			.fetchOne();
+
+		List<SalesDetailResponse> detailResponses = salesIds.stream()
+			.map(salesId -> findSalesDetailById(salesId, memberId))
+			.filter(detail -> detail != null)
+			.collect(Collectors.toList());
+
+		return new PageImpl<>(detailResponses, pageable, total != null ? total : 0L);
+	}
+
+	private BooleanExpression memberIdEq(Long memberId) {
+		return memberId != null ? sales.memberId.eq(memberId) : null;
+	}
+
+	private BooleanExpression createdTimeBetween(LocalDate startDate, LocalDate endDate) {
+		if (startDate != null && endDate != null) {
+			LocalDateTime startDateTime = startDate.atStartOfDay();
+			LocalDateTime endDateTime = endDate.atStartOfDay();
+			return sales.createdTime.between(startDateTime, endDateTime);
+		}
+		if (startDate != null) {
+			return sales.createdTime.goe(startDate.atStartOfDay());
+		}
+		if (endDate != null) {
+			return sales.createdTime.lt(endDate.atStartOfDay());
+		}
+		return null;
+	}
+
+	private BooleanExpression salesStatusEq(SalesStatus salesStatus) {
+		return salesStatus != null ? sales.salesStatus.eq(salesStatus) : null;
+	}
+
 }

--- a/src/main/java/com/zeebra/domain/product/service/SalesService.java
+++ b/src/main/java/com/zeebra/domain/product/service/SalesService.java
@@ -1,9 +1,15 @@
 package com.zeebra.domain.product.service;
 
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Pageable;
+
 import com.zeebra.domain.order.dto.SalesItem;
 import com.zeebra.domain.product.dto.SalesDetailResponse;
+import com.zeebra.domain.product.dto.SalesListResponse;
 import com.zeebra.domain.product.dto.SalesRequest;
 import com.zeebra.domain.product.dto.SalesResponse;
+import com.zeebra.domain.product.entity.SalesStatus;
 import com.zeebra.global.ApiResponse;
 
 public interface SalesService {
@@ -15,4 +21,6 @@ public interface SalesService {
 	SalesItem findCheapestSalesByProductOptionId(Long productOptionId);
 
 	SalesDetailResponse getSalesDetail(Long memberId, Long salesId);
+
+	SalesListResponse getSalesList(Long memberId, LocalDate startDate, LocalDate endDate, SalesStatus salesStatus, Pageable pageable);
 }

--- a/src/main/java/com/zeebra/domain/product/service/SalesServiceImp.java
+++ b/src/main/java/com/zeebra/domain/product/service/SalesServiceImp.java
@@ -1,7 +1,10 @@
 package com.zeebra.domain.product.service;
 
+import java.time.LocalDate;
 import java.util.NoSuchElementException;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,6 +12,7 @@ import com.zeebra.domain.member.entity.Member;
 import com.zeebra.domain.member.repository.MemberRepository;
 import com.zeebra.domain.order.dto.SalesItem;
 import com.zeebra.domain.product.dto.SalesDetailResponse;
+import com.zeebra.domain.product.dto.SalesListResponse;
 import com.zeebra.domain.product.dto.SalesRequest;
 import com.zeebra.domain.product.dto.SalesResponse;
 import com.zeebra.domain.product.entity.ProductOption;
@@ -115,5 +119,29 @@ public class SalesServiceImp implements SalesService {
 		}
 
 		return salesDetailResponse;
+	}
+
+	@Override
+	public SalesListResponse getSalesList(Long memberId, LocalDate startDate, LocalDate endDate,
+		SalesStatus salesStatus, Pageable pageable) {
+		if (memberId == null) {
+			throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
+		}
+
+		if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+			throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
+		}
+
+		LocalDate adjustedEndDate = endDate != null ? endDate.plusDays(1) : null;
+
+		Page<SalesDetailResponse> salesResponsePage = salesQueryRepository.findSalesDetailsByConditions(
+			memberId,
+			startDate,
+			adjustedEndDate,
+			salesStatus,
+			pageable
+		);
+
+		return SalesListResponse.of(salesResponsePage);
 	}
 }


### PR DESCRIPTION
## 관련 이슈
- Jira: ZBR-143
- GitHub: Closes #122

## 어떤 이유로 MR을 하셨나요?
- [x] 기능 추가

## 스크린샷 및 간단한 설명
> 판매 목록 조회 API 및 서비스가 추가되었습니다.  
> - `SalesController` 경로에 판매 목록 조회 API가 포함되었습니다.  
> - 판매를 조건별(Pageable, 기간, 상태 등)로 조회할 수 있는 기능을 추가했습니다.  
> - 예외 처리 로직이 포함된 조회 응답 DTO(`SalesListResponse`)가 구현되었습니다.  

## MR 전에 확인해주세요
- [x] **develop** 브랜치로 PR을 생성했나요?
- [x] Docker 빌드 후 테스트를 완료했나요?
- [x] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [x] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?

[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ