### PR TITLE
[ZBR-159]워크플로우에 test 브랜치 타입 허용 추가

### DIFF
--- a/.github/workflows/create-branch-by-label.yml
+++ b/.github/workflows/create-branch-by-label.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.label.name == 'create-branch'
     uses: zeebra-profect/.github/.github/workflows/issue-create-branch.yml@main
     with:
-      allowed_branch_types: feature,hotfix,release
+      allowed_branch_types: feature,hotfix,release,test
       base_ref: develop  
       jira_key_prefix: ZBR
     secrets: inherit

--- a/.github/workflows/create-branch-by-slash.yml
+++ b/.github/workflows/create-branch-by-slash.yml
@@ -38,7 +38,7 @@ jobs:
        github.event.comment.author_association == 'MEMBER')
     uses: zeebra-profect/.github/.github/workflows/issue-create-branch.yml@main
     with:
-      allowed_branch_types: feature,hotfix,release
+      allowed_branch_types: feature,hotfix,release,test
       base_ref: ${{ needs.parse-base.outputs.base_ref }}
       jira_key_prefix: ZBR
     secrets: inherit


### PR DESCRIPTION
ZBR-159

## 관련 이슈
- Jira: ZBR-159
- GitHub: Closes #138 
<!-- 참조 시 Refs -->

## 어떤 이유로 MR을 하셨나요?
- [x] 기타 사소한 수정

## 스크린샷 및 간단한 설명
> 워크플로우에 test 브랜치 타입 허용 추가

## MR 전에 확인해주세요
- [x] **develop** 브랜치로 PR을 생성했나요?
- [] Docker 빌드 후 테스트를 완료했나요?
- [x] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [x] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?

[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ