### PR TITLE
[ZBR-188] fix: 멤버 ID 시퀀스 동기화 로직 추가

### DIFF
--- a/src/main/java/com/zeebra/domain/member/config/MemberIdSequenceSynchronizer.java
+++ b/src/main/java/com/zeebra/domain/member/config/MemberIdSequenceSynchronizer.java
@@ -1,0 +1,28 @@
+package com.zeebra.domain.member.config;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberIdSequenceSynchronizer {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@PostConstruct
+	public void syncMemberIdSequence() {
+		Long maxId = jdbcTemplate.queryForObject(
+			"SELECT COALESCE(MAX(member_id), 0) FROM members",
+			Long.class
+		);
+
+		jdbcTemplate.queryForObject(
+			"SELECT setval('members_member_id_seq', ?)",
+			Long.class,
+			maxId
+		);
+	}
+}


### PR DESCRIPTION
<!--
# 🚨 필독 🚨
- MAIN 브랜치가 아닌 **develop** 브랜치로 PR을 생성해주세요.
- PR 제목은 `[ZBR-123] feature-login` (대문자 프로젝트키 + 숫자)형식으로 작성해주세요.
-->

## 관련 이슈
- Jira: ZBR-188
- Github: Closes #175
<!-- 참조 시 Refs -->

## 어떤 이유로 MR을 하셨나요?
- [x] 버그 수정

## 스크린샷 및 간단한 설명
> 애플리케이션 시작 시, 멤버 ID의 시퀀스가 테이블의 최대 ID와 동기화되지 않는 문제를 해결했습니다.  
`@PostConstruct`를 통해, 시작 시 자동으로 `members_member_id_seq` 시퀀스가 멤버 테이블의 최대 ID와 동기화되도록 처리하였습니다.

## MR 전에 확인해주세요
- [ ] **develop** 브랜치로 PR을 생성했나요?
- [ ] Docker 빌드 후 테스트를 완료했나요?
- [ ] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [ ] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?

[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ