### PR TITLE
[ZBR-188] fix: 멤버 ID 시퀀스 동기화 로직 수정

### DIFF
--- a/src/main/java/com/zeebra/domain/member/config/MemberIdSequenceSynchronizer.java
+++ b/src/main/java/com/zeebra/domain/member/config/MemberIdSequenceSynchronizer.java
@@ -14,14 +14,20 @@ public class MemberIdSequenceSynchronizer {
 
 	@PostConstruct
 	public void syncMemberIdSequence() {
+		String sequenceName = jdbcTemplate.queryForObject(
+			"SELECT pg_get_serial_sequence('members', 'member_id')",
+			String.class
+		);
+
 		Long maxId = jdbcTemplate.queryForObject(
 			"SELECT COALESCE(MAX(member_id), 0) FROM members",
 			Long.class
 		);
 
 		jdbcTemplate.queryForObject(
-			"SELECT setval('members_member_id_seq', ?)",
+			"SELECT setval(?::regclass, ?)",
 			Long.class,
+			sequenceName,
 			maxId
 		);
 	}


### PR DESCRIPTION
<!--
# 🚨 필독 🚨
- MAIN 브랜치가 아닌 **develop** 브랜치로 PR을 생성해주세요.
- PR 제목은 `[ZBR-123] feature-login` (대문자 프로젝트키 + 숫자)형식으로 작성해주세요.
-->

## 관련 이슈
- Jira: ZBR-188
<!-- 참조 시 Refs -->

## 어떤 이유로 MR을 하셨나요?
- [ ] 기능 추가
- [x] 버그 수정


## 스크린샷 및 간단한 설명
> 멤버 ID 시퀀스 동기화 로직을 수정했습니다. 시퀀스 이름을 동적으로 조회하도록 `pg_get_serial_sequence`를 추가하였으며, 기존의 하드코딩(`members_member_id_seq`)을 제거하여 더 유연한 처리가 가능하도록 개선했습니다.

## MR 전에 확인해주세요
- [ ] **develop** 브랜치로 PR을 생성했나요?
- [ ] Docker 빌드 후 테스트를 완료했나요?
- [ ] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [ ] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?

[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ