### PR TITLE
[ZBR-227] `TossPaymentService`의 `approve` 메서드에 테스트 모드 플래그(isTest) 추가 및 관련 코드 리팩토링

### DIFF
--- a/src/main/java/com/zeebra/domain/payment/dto/ApprovePaymentRequest.java
+++ b/src/main/java/com/zeebra/domain/payment/dto/ApprovePaymentRequest.java
@@ -9,6 +9,7 @@ public record ApprovePaymentRequest(
 	@NotBlank String paymentKey,
 	@NotBlank String tossOrderId,
 	@NotNull BigDecimal amount,
-	@NotBlank String clientRequestId
+	@NotBlank String clientRequestId,
+	boolean isTest
 ) {
 }

--- a/src/main/java/com/zeebra/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/zeebra/domain/payment/service/PaymentServiceImpl.java
@@ -85,7 +85,8 @@ public class PaymentServiceImpl implements PaymentService {
 		// 2단계: 토스 API 호출 (트랜잭션 외부)
 		TossApprovalResponse tossResponse;
 		try {
-			tossResponse = callTossApprovalApi(request.paymentKey(), request.tossOrderId(), request.amount());
+			tossResponse = callTossApprovalApi(request.paymentKey(), request.tossOrderId(), request.amount(),
+				request.isTest());
 		} catch (Exception e) {
 			paymentApprovalProcessor.handleApiCallException(payment, e, request.clientRequestId(), memberId);
 			throw new BusinessException(PaymentErrorCode.TOSS_API_ERROR);
@@ -123,8 +124,8 @@ public class PaymentServiceImpl implements PaymentService {
 
 	// ========== Private Methods ==========
 
-	private TossApprovalResponse callTossApprovalApi(String paymentKey, String tossOrderId, BigDecimal amount) {
-		return tossPaymentService.approve(paymentKey, tossOrderId, amount);
+	private TossApprovalResponse callTossApprovalApi(String paymentKey, String tossOrderId, BigDecimal amount, boolean isTest) {
+		return tossPaymentService.approve(paymentKey, tossOrderId, amount, isTest);
 	}
 
 	private Payment findPaymentByTossOrderId(String tossOrderId) {

--- a/src/main/java/com/zeebra/domain/payment/service/TossPaymentService.java
+++ b/src/main/java/com/zeebra/domain/payment/service/TossPaymentService.java
@@ -5,5 +5,5 @@ import java.math.BigDecimal;
 import com.zeebra.domain.payment.dto.TossApprovalResponse;
 
 public interface TossPaymentService {
-	TossApprovalResponse approve(String paymentKey, String tossOrderId, BigDecimal amount);
+	TossApprovalResponse approve(String paymentKey, String tossOrderId, BigDecimal amount, boolean isTest);
 }

--- a/src/main/java/com/zeebra/domain/payment/service/TossPaymentServiceImpl.java
+++ b/src/main/java/com/zeebra/domain/payment/service/TossPaymentServiceImpl.java
@@ -33,14 +33,16 @@ import lombok.extern.slf4j.Slf4j;
 public class TossPaymentServiceImpl implements TossPaymentService {
 
 	private static final String TOSS_PAYMENTS_BASE_URL = "https://api.tosspayments.com/v1/payments";
+	private static final String TOSS_FAKE_SERVER_URL = "http://localhost:8082";
 	private final RestTemplate restTemplate;
 	private final ObjectMapper objectMapper;
 	@Value("${toss.payments.secret-key}")
 	private String tossSecretKey;
 
 	@Override
-	public TossApprovalResponse approve(String paymentKey, String tossOrderId, BigDecimal amount) {
-		String url = TOSS_PAYMENTS_BASE_URL + "/confirm";
+	public TossApprovalResponse approve(String paymentKey, String tossOrderId, BigDecimal amount, boolean isTest) {
+		String baseUrl = isTest ? TOSS_FAKE_SERVER_URL : TOSS_PAYMENTS_BASE_URL;
+		String url = baseUrl + "/confirm";
 
 		try {
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -81,6 +81,15 @@ management:
       enabled: true
   security:
     enabled: false
+  metrics:
+    enable:
+      http: true
+      jvm: true
+      process: true
+      system: true
+      executor: true
+      hikaricp: true
+      tomcat: true
 
 chat:
   stomp:


### PR DESCRIPTION
## 관련 이슈
- Jira: ZBR-227
- GitHub: Refs #249 

## 어떤 이유로 MR을 하셨나요?
- [x] 코드 개선

## 스크린샷 및 간단한 설명
> `TossPaymentService`의 `approve` 메서드에 테스트 모드 플래그(`isTest`)를 추가하여 테스트 모드 지원을 제공했습니다.  
> 관련 DTO 및 호출부를 수정하고, 개발 환경에서의 메트릭 설정 추가, 테스트 모드 URL 처리를 위한 `TOSS_FAKE_SERVER_URL`도 반영되었습니다.

## MR 전에 확인해주세요
- [x] **develop** 브랜치로 PR을 생성했나요?
- [x] Docker 빌드 후 테스트를 완료했나요?
- [x] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [x] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?

[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ