### PR TITLE
[ZBR-227]Refactor Redis-based stock management and SalesServiceImp

### DIFF
--- a/src/main/java/com/zeebra/domain/product/service/SalesServiceImp.java
+++ b/src/main/java/com/zeebra/domain/product/service/SalesServiceImp.java
@@ -43,6 +43,7 @@ import com.zeebra.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -54,6 +55,7 @@ public class SalesServiceImp implements SalesService {
     private final SalesQueryRepository salesQueryRepository;
     private final ProductQueryRepository productQueryRepository;
     private final ProductRepository productRepository;
+	private final StockRedisService stockRedisService;
 
     private Sales toSales(ProductOption productOption, Member member, SalesRequest request) {
         return new Sales(
@@ -236,54 +238,64 @@ public class SalesServiceImp implements SalesService {
 		 }
 	}
 
-	@Transactional
+	/**
+	 * 재고 예약 (결제 시작 시)
+	 * Redis에서 재고 선차감
+	 */
 	public void reserveSales(List<OrderItemResponse> orderItems) {
-		orderItems.forEach(item -> {
-				Sales sales = salesQueryRepository.findByIdForUpdate(item.saleId());
-				if(sales.getStock() < item.orderItemQuantity()){
-					sales.updateSalesStatus(SalesStatus.PENDING);
-				}
-			});
+		for (int i = 0; i < orderItems.size(); i++) {
+			OrderItemResponse item = orderItems.get(i);
+
+			boolean success = stockRedisService.decreaseStock(
+				item.saleId(),
+				item.orderItemQuantity()
+			);
+
+			if (!success) {
+				// 이미 차감한 것들 롤백
+				rollbackReservedStock(orderItems.subList(0, i));
+				throw new BusinessException(SalesErrorCode.OUT_OF_STOCK);
+			}
+		}
 	}
 
-	@Transactional
+	/**
+	 * 재고 복구 (결제 실패/취소 시)
+	 * Redis 재고 복구
+	 */
 	public void cancelSales(List<OrderItemResponse> orderItems) {
 		orderItems.forEach(item -> {
-				Sales sales = salesQueryRepository.findByIdForUpdate(item.saleId());
-
-				sales.updateStock(sales.getStock() + item.orderItemQuantity());
-				if(sales.getStock() > 0){
-					sales.updateSalesStatus(SalesStatus.ON_SALE);
-				}
-			});
+			stockRedisService.increaseStock(item.saleId(), item.orderItemQuantity());
+		});
 	}
 
+	/**
+	 * 판매 확정 (결제 성공 시)
+	 * DB에 최종 반영 (Redis는 이미 차감됨)
+	 */
 	@Transactional
 	public void confirmSales(List<OrderItemResponse> orderItems) {
 		orderItems.forEach(item -> {
-			Sales sales = salesQueryRepository.findByIdForUpdate(item.saleId());
+			Sales sales = salesRepository.findById(item.saleId())
+				.orElseThrow(() -> new BusinessException(SalesErrorCode.SALES_NOT_FOUND));
 
+			int redisStock = stockRedisService.getStock(item.saleId());
+			sales.updateStock(redisStock);
+			sales.updateSoldPrice(item.orderItemPrice());
 
-			if (sales.getSalesStatus() != SalesStatus.PENDING
-				&& sales.getStock() < item.orderItemQuantity()) {
-				throw new BusinessException(SalesErrorCode.OUT_OF_STOCK);
-			}
-
-			if (sales.getStock() < item.orderItemQuantity()) {
-				throw new BusinessException(SalesErrorCode.OUT_OF_STOCK);
-			}
-
-			int newStock = sales.getStock() - item.orderItemQuantity();
-			sales.updateStock(newStock);
-
-			if (newStock <= 0) {
+			if (redisStock <= 0) {
 				sales.updateSalesStatus(SalesStatus.CONFIRMED);
-			} else if (sales.getSalesStatus() == SalesStatus.PENDING) {
-				// 재고 충분해졌으면 다시 판매 가능 상태로 변경
-				sales.updateSalesStatus(SalesStatus.ON_SALE);
 			}
-				sales.updateSoldPrice(item.orderItemPrice());
-			});
+		});
+	}
+
+	/**
+	 * 예약 실패 시 이미 차감한 재고 롤백
+	 */
+	private void rollbackReservedStock(List<OrderItemResponse> reservedItems) {
+		reservedItems.forEach(item -> {
+			stockRedisService.increaseStock(item.saleId(), item.orderItemQuantity());
+		});
 	}
 
 	private void validateSalesAvailability(Map<Long, Integer> productOptionQuantityMap, List<OrderSalesItem> cheapestSales) {

--- a/src/main/java/com/zeebra/domain/product/service/StockRedisService.java
+++ b/src/main/java/com/zeebra/domain/product/service/StockRedisService.java
@@ -1,0 +1,144 @@
+package com.zeebra.domain.product.service;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import com.zeebra.domain.product.entity.Sales;
+import com.zeebra.domain.product.repository.SalesRepository;
+import com.zeebra.global.ErrorCode.SalesErrorCode;
+import com.zeebra.global.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StockRedisService {
+	private static final String STOCK_KEY_PREFIX = "sales:stock:";
+	// Lua 스크립트: 재고 확인 후 차감 (원자적 연산)
+	private static final String DECREASE_SCRIPT = """
+        local stock = tonumber(redis.call('get', KEYS[1]) or '0')
+        local quantity = tonumber(ARGV[1])
+        if stock >= quantity then
+            return redis.call('decrby', KEYS[1], quantity)
+        else
+            return -1
+        end
+        """;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final SalesRepository salesRepository;
+
+	/**
+	 * 재고 차감 (주문/결제 시)
+	 * @return 성공 시 남은 재고, 실패 시 -1
+	 */
+	public boolean decreaseStock(Long salesId, int quantity) {
+		String key = STOCK_KEY_PREFIX + salesId;
+
+		Long result = redisTemplate.execute(
+			RedisScript.of(DECREASE_SCRIPT, Long.class),
+			List.of(key),
+			String.valueOf(quantity)
+		);
+
+		if (result == null || result < 0) {
+			// DB에서 동기화 후 재시도
+			if (syncStockFromDbIfNeeded(salesId)) {
+				result = redisTemplate.execute(
+					RedisScript.of(DECREASE_SCRIPT, Long.class),
+					List.of(key),
+					String.valueOf(quantity)
+				);
+			}
+		}
+
+		if (result == null || result < 0) {
+			log.warn("[재고 차감 실패] salesId: {}, 요청 수량: {}", salesId, quantity);
+			return false;
+		}
+
+		log.info("[재고 차감 성공] salesId: {}, 차감: {}, 남은 재고: {}", salesId, quantity, result);
+		return true;
+	}
+
+	/**
+	 * 재고 복구 (결제 실패/취소 시)
+	 */
+	public void increaseStock(Long salesId, int quantity) {
+		String key = STOCK_KEY_PREFIX + salesId;
+
+		if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
+			syncStockFromDb(salesId);
+		}
+
+		Long result = redisTemplate.opsForValue().increment(key, quantity);
+		log.info("[재고 복구] salesId: {}, 복구: {}, 현재 재고: {}", salesId, quantity, result);
+	}
+
+	/**
+	 * 재고 조회
+	 */
+	public int getStock(Long salesId) {
+		String key = STOCK_KEY_PREFIX + salesId;
+
+		if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
+			syncStockFromDb(salesId);
+		}
+		String value = redisTemplate.opsForValue().get(key);
+		return value != null ? Integer.parseInt(value) : 0;
+	}
+
+	/**
+	 * 재고 설정 (상품 등록/수정 시 DB → Redis 동기화)
+	 */
+	public void setStock(Long salesId, int stock) {
+		String key = STOCK_KEY_PREFIX + salesId;
+		redisTemplate.opsForValue().set(key, String.valueOf(stock));
+		log.info("[재고 동기화] salesId: {}, stock: {}", salesId, stock);
+	}
+
+	/**
+	 * 재고 삭제 (상품 삭제 시)
+	 */
+	public void deleteStock(Long salesId) {
+		String key = STOCK_KEY_PREFIX + salesId;
+		redisTemplate.delete(key);
+		log.info("[재고 삭제] salesId: {}", salesId);
+	}
+
+	/**
+	 * DB에서 Redis로 재고 동기화
+	 */
+	private void syncStockFromDb(Long salesId) {
+		Sales sales = salesRepository.findById(salesId)
+			.orElseThrow(() -> new BusinessException(SalesErrorCode.SALES_NOT_FOUND));
+
+		setStock(salesId, sales.getStock());
+		log.info("[DB → Redis 동기화] salesId: {}, stock: {}", salesId, sales.getStock());
+	}
+
+	/**
+	 * Redis에 값이 없거나 0이면 DB에서 동기화
+	 */
+	private boolean syncStockFromDbIfNeeded(Long salesId) {
+		String key = STOCK_KEY_PREFIX + salesId;
+		String currentValue = redisTemplate.opsForValue().get(key);
+
+		// 키가 없거나 0이면 DB에서 동기화
+		if (currentValue == null || "0".equals(currentValue)) {
+			Sales sales = salesRepository.findById(salesId)
+				.orElseThrow(() -> new BusinessException(SalesErrorCode.SALES_NOT_FOUND));
+
+			if (sales.getStock() > 0) {
+				setStock(salesId, sales.getStock());
+				log.info("[DB → Redis 동기화] salesId: {}, stock: {}", salesId, sales.getStock());
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/zeebra/domain/product/service/StockRedisService.java
+++ b/src/main/java/com/zeebra/domain/product/service/StockRedisService.java
@@ -2,6 +2,7 @@ package com.zeebra.domain.product.service;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
@@ -11,11 +12,9 @@ import com.zeebra.domain.product.repository.SalesRepository;
 import com.zeebra.global.ErrorCode.SalesErrorCode;
 import com.zeebra.global.exception.BusinessException;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class StockRedisService {
 	private static final String STOCK_KEY_PREFIX = "sales:stock:";
@@ -29,8 +28,16 @@ public class StockRedisService {
             return -1
         end
         """;
+
 	private final RedisTemplate<String, String> redisTemplate;
 	private final SalesRepository salesRepository;
+
+	public StockRedisService(
+		@Qualifier("stockRedisTemplate") RedisTemplate<String, String> redisTemplate,
+		SalesRepository salesRepository) {
+		this.redisTemplate = redisTemplate;
+		this.salesRepository = salesRepository;
+	}
 
 	/**
 	 * 재고 차감 (주문/결제 시)

--- a/src/main/java/com/zeebra/global/config/Redisconfig.java
+++ b/src/main/java/com/zeebra/global/config/Redisconfig.java
@@ -1,7 +1,6 @@
 package com.zeebra.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.data.redis.LettuceClientConfigurationBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -44,6 +43,16 @@ public class Redisconfig {
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
         redisTemplate.afterPropertiesSet();
+		return redisTemplate;
+	}
+
+	@Bean(name = "stockRedisTemplate")
+	public RedisTemplate<String, String> stockRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.afterPropertiesSet();
 		return redisTemplate;
 	}
 }


### PR DESCRIPTION
## 관련 이슈
- Jira: ZBR-227
- GitHUB: Closes #249
<!-- 참조 시 Refs -->

## 어떤 이유로 MR을 하셨나요?
- [x] 코드 개선


## 스크린샷 및 간단한 설명
> Redis 기반 재고 관리 로직을 개선하고 `SalesServiceImp` 메서드를 리팩토링했습니다.

### 주요 변경 사항:
1. **Redis 재고 관리 리팩토링**:
   - 기존 코드를 개선하여 `StockRedisService` 생성 및 Redis CRUD 로직 추가.
   - `RedisTemplate`을 활용하여 재고 동기화 및 연산 처리.

2. **`SalesServiceImp` 메서드 개선**:
   - `reserveSales`: 재고 차감 및 롤백 로직 개선.
   - `confirmSales`: Redis 데이터를 DB에 반영하는 동기화 로직 추가.
   - `cancelSales`: 결제 취소 시 Redis 재고 복구 로직 구현.
   - 판매 상태 및 재고 처리를 흐름에 맞게 정리.

3. **코드 정리**:
   - 불필요한 의존성 및 어노테이션 제거.
   - Lua 스크립트를 사용한 원자적 연산 강화.

## MR 전에 확인해주세요
- [x] **develop** 브랜치로 PR을 생성했나요?
- [x] Docker 빌드 후 테스트를 완료했나요?
- [x] PR 제목에 **Jira 이슈키([ZBR-123])**가 포함되어 있나요?
- [x] PR 본문에 **GitHub 이슈 링크(Closes #NN)**가 포함되어 있나요?

[ZBR-123]: https://northwestii.atlassian.net/browse/ZBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ